### PR TITLE
Smaller version: 6 lines removed

### DIFF
--- a/repike.go
+++ b/repike.go
@@ -6,11 +6,10 @@ func Match(regexp, text string) bool {
 	if regexp != "" && regexp[0] == '^' {
 		return matchHere(regexp[1:], text)
 	}
-	for text != "" {
+	for ; text != ""; text = text[1:] {
 		if matchHere(regexp, text) {
 			return true
 		}
-		text = text[1:]
 	}
 	return matchHere(regexp, text) /* must look even if string is empty */
 }
@@ -32,11 +31,10 @@ func matchHere(regexp, text string) bool {
 
 // matchStar reports whether c*regexp matches at beginning of text.
 func matchStar(c byte, regexp, text string) bool {
-	for text != "" && (text[0] == c || c == '.') {
+	for ; text != "" && (text[0] == c || c == '.'); text = text[1:] {
 		if matchHere(regexp, text) {
 			return true
 		}
-		text = text[1:]
 	}
 	return matchHere(regexp, text) /* must look even if string is empty */
 }

--- a/repike.go
+++ b/repike.go
@@ -6,15 +6,13 @@ func Match(regexp, text string) bool {
 	if regexp != "" && regexp[0] == '^' {
 		return matchHere(regexp[1:], text)
 	}
-	for {
+	for text != "" {
 		if matchHere(regexp, text) {
 			return true
 		}
-		if text == "" {
-			return false
-		}
 		text = text[1:]
 	}
+	return matchHere(regexp, text) /* must look even if string is empty */
 }
 
 // matchHere reports whether regexp matches at beginning of text.
@@ -34,13 +32,11 @@ func matchHere(regexp, text string) bool {
 
 // matchStar reports whether c*regexp matches at beginning of text.
 func matchStar(c byte, regexp, text string) bool {
-	for {
+	for text != "" && (text[0] == c || c == '.') {
 		if matchHere(regexp, text) {
 			return true
 		}
-		if text == "" || (text[0] != c && c != '.') {
-			return false
-		}
 		text = text[1:]
 	}
+	return matchHere(regexp, text) /* must look even if string is empty */
 }


### PR DESCRIPTION
When reading the article I directly see that the `for` in `Match` could be optimized.
Then I see that the same things could be done with `matchStar`.

I think the first change (in `Match`) is OK and its still readable.
For the second one (in `matchStar`), it might remove some readability ?